### PR TITLE
WURFL Cloud client Java

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,10 @@
+1.0.11
+Ehn: upgraded Jackson dependency to v 2.10.x to fix several vulnerabilities
+Ehn: Minimum JDK requirement is now Java 7
+
+1.0.10 
+Ehn: Set HTTPS as connection scheme
+
 1.0.9
 Ehn: Updated and improved Maven repo references in poms.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the Client.
 Setup a Development Environment
 -------------------------------
 
-1. Download and Install a Java JDK version 1.5 or greater
+1. Download and Install a Java JDK version 7 or greater (for compatibility with older Java versions, please use client releases up to 1.0.10)
 2. Download and Install Apache Tomcat version 6 or greater
 3. Download and Install Apache Maven (Tested with version 3.5)
 4. Create a `JAVA_HOME` Environment Variable which points to the location of your

--- a/code/client-java.iml
+++ b/code/client-java.iml
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: javax.servlet:servlet-api:2.4" level="project" />
     <orderEntry type="library" name="Maven: net.sf.ehcache:ehcache-core:2.5.1" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.10.2" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.9.8" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.9.0" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.6.4" level="project" />
-    <orderEntry type="library" name="Maven: org.codehaus.jackson:jackson-core-asl:1.9.5" level="project" />
-    <orderEntry type="library" name="Maven: org.codehaus.jackson:jackson-mapper-asl:1.9.5" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: ch.qos.logback:logback-core:1.0.0" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: ch.qos.logback:logback-classic:1.0.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.testng:testng:5.14.10" level="project" />
@@ -29,4 +30,3 @@
     <orderEntry type="library" name="Maven: org.objenesis:objenesis:1.0" level="project" />
   </component>
 </module>
-

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -290,14 +290,20 @@
 
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>2.0.2</version>
+                        <configuration>
+                            <source>1.6</source>
+                            <target>1.6</target>
+                            <encoding>UTF-8</encoding>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <!-- <version>2.2.1</version> <configuration> <source>1.5</source> 
-                            <target>1.5</target> <encoding>UTF-8</encoding> </configuration> parte del 
-                            source plugin -->
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
-                                <!-- <phase>verify</phase> -->
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>
@@ -306,7 +312,6 @@
                     </plugin>
 
                     <plugin>
-                        <!--<groupId>org.apache.maven.plugins</groupId> -->
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <executions>
                             <execution>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.scientiamobile.wurflcloud</groupId>
     <artifactId>client-java</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <packaging>jar</packaging>
 
     <name>wurfl-cloud-client</name>
@@ -61,7 +61,7 @@
         <testng.version>5.14.10</testng.version>
         <logback.version>1.0.0</logback.version>
         <slf4j.version>1.6.4</slf4j.version>
-        <jackson.version>1.9.5</jackson.version>
+        <jackson.version>2.10.2</jackson.version>
     </properties>
     
     <!-- Dependencies -->
@@ -80,17 +80,16 @@
             <version>2.5.1</version>
             <optional>true</optional>
         </dependency>
-
+        <!-- Jackson 2 -->
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>${jackson.version}</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.8</version>
         </dependency>
 
         <dependency>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -293,8 +293,8 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>2.0.2</version>
                         <configuration>
-                            <source>1.6</source>
-                            <target>1.6</target>
+                            <source>1.7</source>
+                            <target>1.7</target>
                             <encoding>UTF-8</encoding>
                         </configuration>
                     </plugin>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -171,14 +171,6 @@
         <plugins>
 
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>2.4.2</version>
                 <configuration>

--- a/code/src/main/java/com/scientiamobile/wurflcloud/CloudClient.java
+++ b/code/src/main/java/com/scientiamobile/wurflcloud/CloudClient.java
@@ -31,8 +31,7 @@ import java.util.zip.GZIPInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.codehaus.jackson.map.ObjectMapper;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.scientiamobile.wurflcloud.cache.IWurflCloudCache;
 import com.scientiamobile.wurflcloud.device.AbstractDevice;
 import com.scientiamobile.wurflcloud.device.CacheDevice;

--- a/code/src/main/java/com/scientiamobile/wurflcloud/cache/SimpleCookieCache.java
+++ b/code/src/main/java/com/scientiamobile/wurflcloud/cache/SimpleCookieCache.java
@@ -20,8 +20,8 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.codehaus.jackson.map.ObjectMapper;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.scientiamobile.wurflcloud.ICloudClientRequest;
 import com.scientiamobile.wurflcloud.device.AbstractDevice;
 import com.scientiamobile.wurflcloud.device.CookieDevice;

--- a/code/src/main/java/com/scientiamobile/wurflcloud/utils/Constants.java
+++ b/code/src/main/java/com/scientiamobile/wurflcloud/utils/Constants.java
@@ -24,7 +24,7 @@ public interface Constants {
     /**
      * The version of this client
      */
-    String CLIENT_VERSION = "1.0.10";
+    String CLIENT_VERSION = "1.0.11";
 
     /**
      * Accepted encoding enum.

--- a/code/src/test/java/com/scientiamobile/wurflcloud/CloudClientConnectionTimeoutTest.java
+++ b/code/src/test/java/com/scientiamobile/wurflcloud/CloudClientConnectionTimeoutTest.java
@@ -42,7 +42,7 @@ public class CloudClientConnectionTimeoutTest extends Loggable{
         
         cfg = new CloudClientConfig();
         cfg.clearServers();
-        cfg.addCloudServer("timeout_server", "8.8.8.8", 10);
+        cfg.addCloudServer("timeout_server", "www.google.com:81", 10);
         cfg.apiKey = "XXXXXX:YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY";
         cfg.connectionTimeout = 2000;
         am = new AuthenticationManager(cfg);

--- a/code/src/test/java/com/scientiamobile/wurflcloud/CloudResponseTest.java
+++ b/code/src/test/java/com/scientiamobile/wurflcloud/CloudResponseTest.java
@@ -11,7 +11,7 @@
  */
 package com.scientiamobile.wurflcloud;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.scientiamobile.wurflcloud</groupId>
     <artifactId>client-example</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.11</version>
     <packaging>war</packaging>
 
     <name>WURFL Cloud Client example webapp</name>
@@ -153,8 +153,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This PR introduces several changes:

- Upgrades Jackson dependency from 1.9.x to 2.10.x which resolves vulnerability reported in https://scientia.atlassian.net/browse/CCLJ-38 (and several other Jackson bugs).

- Updates code to import the new Jackson classes (while they didn't break the interface method signatures, the package name changes, so we need to update them).

- From now on, minimum Java version required to compile a program that uses wurfl cloud client is 7, which is needed to compile the new Jackson dependency. Users who need to compile with older Java version must use older versions of the client.