### PR TITLE
1.11.0: replaced jsoniter with gson library

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+1.11.0
+Fix and ehn: replaced jsoniter with Gson due to some jsoniter deserialization issue and an unfixed severe security alert (CVE-2021-23441).
+
 1.0.15
 Fix: Updated logback dependency due to discovered vulnerability.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,3 +6,5 @@ The WURFL Cloud Client for Java is released under the GNU GENERAL PUBLIC LICENSE
 Contributors agree that any contributions are owned by the copyright holder and that contributors have absolutely no rights to their contributions.
 
 To get started, sign the [Contributor License Agreement](https://www.clahub.com/agreements/WURFL/wurfl-cloud-client-java).
+
+Full text of the GPL 2.0 and MIT licenses are available in the `LICENSE-*.txt` files

--- a/LICENSE-MIT.txt
+++ b/LICENSE-MIT.txt
@@ -1,0 +1,24 @@
+(c) Copyright 2011 - 2021 Scientiamobile Inc.
+
+
+Licensed under the MIT license:
+
+    http://www.opensource.org/licenses/mit-license.php
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/LICENSE-gpl-2.0.txt
+++ b/LICENSE-gpl-2.0.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/code/client-java.iml
+++ b/code/client-java.iml
@@ -19,7 +19,7 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: javax.servlet:servlet-api:2.4" level="project" />
     <orderEntry type="library" name="Maven: net.sf.ehcache:ehcache-core:2.5.1" level="project" />
-    <orderEntry type="library" name="Maven: com.jsoniter:jsoniter:0.9.23" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.8.8" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.6.4" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: ch.qos.logback:logback-core:1.2.0" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: ch.qos.logback:logback-classic:1.2.0" level="project" />

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.scientiamobile.wurflcloud</groupId>
     <artifactId>client-java</artifactId>
-    <version>1.11.10</version>
+    <version>1.11.0</version>
     <packaging>jar</packaging>
 
     <name>wurfl-cloud-client</name>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -84,9 +84,9 @@
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.jsoniter/jsoniter -->
         <dependency>
-            <groupId>com.jsoniter</groupId>
-            <artifactId>jsoniter</artifactId>
-            <version>0.9.23</version>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.8</version>
         </dependency>
 
 

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.scientiamobile.wurflcloud</groupId>
     <artifactId>client-java</artifactId>
-    <version>1.0.15</version>
+    <version>1.11.10</version>
     <packaging>jar</packaging>
 
     <name>wurfl-cloud-client</name>

--- a/code/src/main/java/com/scientiamobile/wurflcloud/CloudClient.java
+++ b/code/src/main/java/com/scientiamobile/wurflcloud/CloudClient.java
@@ -360,7 +360,6 @@ public class CloudClient extends Loggable implements ICloudClientRequest, Consta
      */
     private CloudResponse processResponse(String rawData) {
         try {
-            //return deserialize(rawData, CloudResponse.class);
             return gson.fromJson(rawData, CloudResponse.class);
         } catch (Exception e) {
             throw new WURFLCloudClientException("", HTTP_ERROR_JSON_KEY);

--- a/code/src/main/java/com/scientiamobile/wurflcloud/CloudClient.java
+++ b/code/src/main/java/com/scientiamobile/wurflcloud/CloudClient.java
@@ -31,6 +31,7 @@ import java.util.zip.GZIPInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.gson.Gson;
 import com.scientiamobile.wurflcloud.cache.IWurflCloudCache;
 import com.scientiamobile.wurflcloud.device.AbstractDevice;
 import com.scientiamobile.wurflcloud.device.CacheDevice;
@@ -40,8 +41,6 @@ import com.scientiamobile.wurflcloud.exc.WURFLCloudClientException;
 import com.scientiamobile.wurflcloud.utils.AuthorizationUtils;
 import com.scientiamobile.wurflcloud.utils.Constants;
 import com.scientiamobile.wurflcloud.utils.Credentials;
-
-import static com.jsoniter.JsonIterator.deserialize;
 
 
 /**
@@ -61,6 +60,7 @@ public class CloudClient extends Loggable implements ICloudClientRequest, Consta
     private final Credentials credentials;
     private final IWurflCloudCache cache;
     private final Set<CloudListener> listeners = new HashSet<CloudListener>();
+    private final Gson gson = new Gson();
     
     private static final int HTTP_ERROR_INVALID_KEY = 401;
     private static final int HTTP_ERROR_MISSING_KEY = 402;
@@ -360,7 +360,8 @@ public class CloudClient extends Loggable implements ICloudClientRequest, Consta
      */
     private CloudResponse processResponse(String rawData) {
         try {
-            return deserialize(rawData, CloudResponse.class);
+            //return deserialize(rawData, CloudResponse.class);
+            return gson.fromJson(rawData, CloudResponse.class);
         } catch (Exception e) {
             throw new WURFLCloudClientException("", HTTP_ERROR_JSON_KEY);
         }

--- a/code/src/main/java/com/scientiamobile/wurflcloud/cache/SimpleCookieCache.java
+++ b/code/src/main/java/com/scientiamobile/wurflcloud/cache/SimpleCookieCache.java
@@ -20,13 +20,11 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.jsoniter.output.JsonStream;
+import com.google.gson.Gson;
 import com.scientiamobile.wurflcloud.ICloudClientRequest;
 import com.scientiamobile.wurflcloud.device.AbstractDevice;
 import com.scientiamobile.wurflcloud.device.CookieDevice;
 import com.scientiamobile.wurflcloud.device.JsonCookie;
-
-import static com.jsoniter.JsonIterator.deserialize;
 
 /**
  * Cache implementation using Cookies.
@@ -43,6 +41,8 @@ public class SimpleCookieCache extends AbstractWurflCloudCache {
      * Cookie encoding charset
      */
     private static final String US_ASCII = "US-ASCII";
+
+    private final Gson gson = new Gson();
 
     @Override
     protected boolean purgeInternal() {
@@ -64,7 +64,7 @@ public class SimpleCookieCache extends AbstractWurflCloudCache {
                 try {
                     value = URLDecoder.decode(value, US_ASCII);
                     if (logger.isDebugEnabled()) logger.debug("decoded cookie value: " + value);
-                    JsonCookie jc = deserialize(value, JsonCookie.class);
+                    JsonCookie jc = gson.fromJson(value, JsonCookie.class);
                     long expiration = jc.getDate_set() + COOKIE_CACHE_EXPIRATION;
                     long nowSecs = System.currentTimeMillis() / 1000;
                     if (expiration < nowSecs) {
@@ -101,7 +101,8 @@ public class SimpleCookieCache extends AbstractWurflCloudCache {
         long nowSecs = System.currentTimeMillis() / 1000;
         JsonCookie jsonCookie = new JsonCookie(capabilitiesMap, nowSecs, device.getId());
         try {
-            cookieVal = JsonStream.serialize(jsonCookie);
+            //cookieVal = JsonStream.serialize(jsonCookie);
+            cookieVal = gson.toJson(jsonCookie);
             logger.debug("cookie value: " + cookieVal);
             cookieVal = URLEncoder.encode(cookieVal, US_ASCII);
             logger.debug("encoded cookie value: " + cookieVal);

--- a/code/src/main/java/com/scientiamobile/wurflcloud/cache/SimpleCookieCache.java
+++ b/code/src/main/java/com/scientiamobile/wurflcloud/cache/SimpleCookieCache.java
@@ -99,10 +99,7 @@ public class SimpleCookieCache extends AbstractWurflCloudCache {
         String cookieVal;
         HashMap<String, Object> capabilitiesMap = new HashMap<String, Object>(device.getCapabilities());
         long nowSecs = System.currentTimeMillis() / 1000;
-        JsonCookie jsonCookie = new JsonCookie();
-        jsonCookie.setCapabilities(capabilitiesMap);
-        jsonCookie.setDate_set(String.valueOf(nowSecs));
-        jsonCookie.setId(device.getId());
+        JsonCookie jsonCookie = new JsonCookie(capabilitiesMap, nowSecs, device.getId());
         try {
             cookieVal = JsonStream.serialize(jsonCookie);
             logger.debug("cookie value: " + cookieVal);

--- a/code/src/main/java/com/scientiamobile/wurflcloud/device/JsonCookie.java
+++ b/code/src/main/java/com/scientiamobile/wurflcloud/device/JsonCookie.java
@@ -11,11 +11,10 @@
  */
 package com.scientiamobile.wurflcloud.device;
 
-import com.scientiamobile.wurflcloud.utils.AuthorizationUtils;
+import com.jsoniter.annotation.JsonCreator;
+import com.jsoniter.annotation.JsonProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -23,9 +22,22 @@ import java.util.Map;
  */
 public class JsonCookie {
     private Map<String, Object> capabilities;
-    private String date_set;
-    private long ldate_set;
+    private long date_set;
     private String id;
+
+    @JsonCreator
+    public JsonCookie(
+            @JsonProperty("capabilities")
+            Map<String, Object> capabilities,
+            @JsonProperty("date_set")
+            long date,
+            @JsonProperty("id")
+            String devId)
+    {
+        this.capabilities = capabilities;
+        this.date_set = date;
+        this.id = devId;
+    }
 
     /**
      * Gets the capability map.
@@ -37,28 +49,8 @@ public class JsonCookie {
 
     private static final Logger logger = LoggerFactory.getLogger(JsonCookie.class);
 
-    /**
-     * Sets the capability map
-     * @param capabilities The new capability map
-     */
-    public void setCapabilities(HashMap<String, Object> capabilities) {
-        this.capabilities = capabilities;
-    }
-
     public long getDate_set() {
-        return ldate_set;
-    }
-
-    public void setDate_set(String date_set) {
-        this.date_set = date_set;
-        try {
-            // json iter may have problems parsing long values that arrive as strings, so we do it explicitly
-            this.ldate_set = Long.parseLong(this.date_set);
-        }
-        catch (Exception e){
-            logger.error("Unable to parse date_set field value " + this.date_set + " : it is not a number");
-        }
-
+        return date_set;
     }
 
     /**
@@ -67,13 +59,5 @@ public class JsonCookie {
      */
     public String getId() {
         return id;
-    }
-
-    /**
-     * Sets the cookie identifier
-     * @param id The cookie identifier
-     */
-    public void setId(String id) {
-        this.id = id;
     }
 }

--- a/code/src/main/java/com/scientiamobile/wurflcloud/device/JsonCookie.java
+++ b/code/src/main/java/com/scientiamobile/wurflcloud/device/JsonCookie.java
@@ -11,28 +11,25 @@
  */
 package com.scientiamobile.wurflcloud.device;
 
-import com.jsoniter.annotation.JsonCreator;
-import com.jsoniter.annotation.JsonProperty;
+import com.google.gson.annotations.SerializedName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.util.Map;
 
 /**
  * Bean serialized from/to a cookie.
  */
 public class JsonCookie {
-    private Map<String, Object> capabilities;
-    private long date_set;
-    private String id;
 
-    @JsonCreator
-    public JsonCookie(
-            @JsonProperty("capabilities")
-            Map<String, Object> capabilities,
-            @JsonProperty("date_set")
-            long date,
-            @JsonProperty("id")
-            String devId)
+    @SerializedName("capabilities")
+    Map<String, Object> capabilities;
+    @SerializedName("date_set")
+    long date_set;
+    @SerializedName("id")
+    String id;
+
+    public JsonCookie(Map<String, Object> capabilities, long date, String devId)
     {
         this.capabilities = capabilities;
         this.date_set = date;
@@ -51,6 +48,18 @@ public class JsonCookie {
 
     public long getDate_set() {
         return date_set;
+    }
+
+    public void setDate_set(long date_set) {
+        this.date_set = date_set;
+    }
+
+    public void setCapabilities(Map<String, Object> capabilities) {
+        this.capabilities = capabilities;
+    }
+
+    public void setId(String id) {
+        this.id = id;
     }
 
     /**

--- a/code/src/main/java/com/scientiamobile/wurflcloud/utils/Constants.java
+++ b/code/src/main/java/com/scientiamobile/wurflcloud/utils/Constants.java
@@ -24,7 +24,7 @@ public interface Constants {
     /**
      * The version of this client
      */
-    String CLIENT_VERSION = "1.0.15";
+    String CLIENT_VERSION = "1.11.0";
 
     /**
      * Accepted encoding enum.

--- a/code/src/test/java/com/scientiamobile/wurflcloud/CloudClientHashMapCacheTest.java
+++ b/code/src/test/java/com/scientiamobile/wurflcloud/CloudClientHashMapCacheTest.java
@@ -18,7 +18,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Enumeration;

--- a/code/src/test/java/com/scientiamobile/wurflcloud/CloudResponseTest.java
+++ b/code/src/test/java/com/scientiamobile/wurflcloud/CloudResponseTest.java
@@ -11,11 +11,10 @@
  */
 package com.scientiamobile.wurflcloud;
 
+import com.google.gson.Gson;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-
-import static com.jsoniter.JsonIterator.deserialize;
 import static org.testng.Assert.assertNotNull;
 
 /**
@@ -26,10 +25,11 @@ import static org.testng.Assert.assertNotNull;
 @Test
 public class CloudResponseTest extends Loggable {
 
+    private final Gson gson = new Gson();
 
     public void testRawData() throws IOException {
         String rawData = "{\"apiVersion\":\"WurflCloud 2.1.6\",\"mtime\":1310581109,\"id\":\"mozilla_ver5\",\"capabilities\":{\"resolution_height\":600,\"resolution_width\":800},\"errors\":{}}";
-        CloudResponse cloudResponse = deserialize(rawData, CloudResponse.class);
+        CloudResponse cloudResponse = gson.fromJson(rawData, CloudResponse.class);
         assertNotNull(cloudResponse);
         logger.info(cloudResponse.toString());
     }

--- a/code/src/test/java/com/scientiamobile/wurflcloud/JSONCookieSerdeTest.java
+++ b/code/src/test/java/com/scientiamobile/wurflcloud/JSONCookieSerdeTest.java
@@ -1,3 +1,14 @@
+/**
+ * Copyright (c) 2015 ScientiaMobile Inc.
+ *
+ * The WURFL Cloud Client is intended to be used in both open-source and
+ * commercial environments. To allow its use in as many situations as possible,
+ * the WURFL Cloud Client is dual-licensed. You may choose to use the WURFL
+ * Cloud Client under either the GNU GENERAL PUBLIC LICENSE, Version 2.0, or
+ * the MIT License.
+ *
+ * Refer to the COPYING.txt file distributed with this package.
+ */
 package com.scientiamobile.wurflcloud;
 
 import static org.testng.Assert.assertNotNull;

--- a/code/src/test/java/com/scientiamobile/wurflcloud/JSONCookieSerdeTest.java
+++ b/code/src/test/java/com/scientiamobile/wurflcloud/JSONCookieSerdeTest.java
@@ -1,10 +1,9 @@
 package com.scientiamobile.wurflcloud;
 
-import static com.jsoniter.JsonIterator.deserialize;
-import static com.jsoniter.output.JsonStream.serialize;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertEquals;
 
+import com.google.gson.Gson;
 import com.scientiamobile.wurflcloud.device.JsonCookie;
 import org.testng.annotations.Test;
 import java.util.HashMap;
@@ -16,15 +15,17 @@ public class JSONCookieSerdeTest {
 
     @Test(groups = "unit")
     public void testSerializationDeserializationTest() {
+
+        Gson gson = new Gson();
         Map<String,Object> capabilities = new HashMap<>();
         capabilities.put("brand_name", "Apple");
         capabilities.put("model_name", "iPad Pro 11");
 
         JsonCookie cookie = new JsonCookie(capabilities, 163265896L, "apple_ipad_ver1_sub13_7_subhwpro3110");
-        String jsonString = serialize(cookie);
+        String jsonString = gson.toJson(cookie);
         assertNotNull(jsonString);
 
-        JsonCookie deserializedCookie = deserialize(jsonString, JsonCookie.class);
+        JsonCookie deserializedCookie = gson.fromJson(jsonString, JsonCookie.class);
         assertNotNull(deserializedCookie);
         assertEquals(cookie.getDate_set(), deserializedCookie.getDate_set());
         assertEquals(cookie.getCapabilities().size(), deserializedCookie.getCapabilities().size());

--- a/code/src/test/java/com/scientiamobile/wurflcloud/JSONCookieSerdeTest.java
+++ b/code/src/test/java/com/scientiamobile/wurflcloud/JSONCookieSerdeTest.java
@@ -1,0 +1,33 @@
+package com.scientiamobile.wurflcloud;
+
+import static com.jsoniter.JsonIterator.deserialize;
+import static com.jsoniter.output.JsonStream.serialize;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+
+import com.scientiamobile.wurflcloud.device.JsonCookie;
+import org.testng.annotations.Test;
+import java.util.HashMap;
+import java.util.Map;
+
+
+@Test(groups = "unit")
+public class JSONCookieSerdeTest {
+
+    @Test(groups = "unit")
+    public void testSerializationDeserializationTest() {
+        Map<String,Object> capabilities = new HashMap<>();
+        capabilities.put("brand_name", "Apple");
+        capabilities.put("model_name", "iPad Pro 11");
+
+        JsonCookie cookie = new JsonCookie(capabilities, 163265896L, "apple_ipad_ver1_sub13_7_subhwpro3110");
+        String jsonString = serialize(cookie);
+        assertNotNull(jsonString);
+
+        JsonCookie deserializedCookie = deserialize(jsonString, JsonCookie.class);
+        assertNotNull(deserializedCookie);
+        assertEquals(cookie.getDate_set(), deserializedCookie.getDate_set());
+        assertEquals(cookie.getCapabilities().size(), deserializedCookie.getCapabilities().size());
+        assertEquals(cookie.getId(), deserializedCookie.getId());
+    }
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.scientiamobile.wurflcloud</groupId>
     <artifactId>client-example</artifactId>
-    <version>1.0.15</version>
+    <version>1.11.0</version>
     <packaging>war</packaging>
 
     <name>WURFL Cloud Client example webapp</name>


### PR DESCRIPTION
This PR replaces jsoniter library with gson for the following reason:

- while a good choice in terms of performance, jsoniter has some issues while deserializing some data types (ie: long values representing timestamps) 
- a new, severe, not yet fixed, security alert has been issued for jsoniter and, since the project is apparently frozen, we cannot wait to see whether it is updated or not.